### PR TITLE
add config-v2

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,6 @@
 name: 'heap'
 version: '1.0'
+config-version: 2
 
 source-paths: ["models"]   # paths with source code to compile
 analysis-paths: ["analysis"] # path with analysis files which are compiled, but not run


### PR DESCRIPTION
In order to comply with dbt version 17.0, a `config-version` variable must be added